### PR TITLE
position-fixed container ( instead of absolute )

### DIFF
--- a/jquery.fullscreenslides.js
+++ b/jquery.fullscreenslides.js
@@ -306,7 +306,7 @@
     $container.data("options", options);
     // Apply default styles
     $container.css({
-      "position"         : "absolute",
+      "position"         : "fixed",
       "top"              : "0px",
       "left"             : "0px",
       "width"            : "100%",


### PR DESCRIPTION
This fixes the issue #3 "Scrolling while viewing gallery (for browsers with no fullscreen support)"

On long pages, the container being loaded at the top of the page was not visible anymore. With fixed positioning the container is always viewable. 
