### PR TITLE
fix missing var keyword

### DIFF
--- a/jquery.fullscreenslides.js
+++ b/jquery.fullscreenslides.js
@@ -252,7 +252,7 @@
       $(document).bind("keydown", keyFunc);
       // Use the fancy new FullScreenAPI:
       if (options.useFullScreen) {
-        con = $container[0];
+        var con = $container[0];
         if (con.requestFullScreen) {
           con.requestFullScreen();
           document.addEventListener('fullscreenchange', changeFullScreenHandler);


### PR DESCRIPTION
if you are using a build system which is using strict mode or babel,
this var keyword is needed
